### PR TITLE
Use alternate delimeter for sed

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,7 +11,7 @@ RUN echo "deb http://pipplware.pplware.pt/pipplware/dists/jessie/main/binary /" 
 wget -O - http://pipplware.pplware.pt/pipplware/key.asc | sudo apt-key add -
 
 # WTF is going on with httpredir from debian? removing it the dirty way
-RUN sed -i "s/httpredir.debian.org/`curl -s -D - http://httpredir.debian.org/demo/debian/ | awk '/^Link:/ { print $2 }' | sed -e 's@<http://\(.*\)/debian/>;@\1@g'`/" /etc/apt/sources.list
+RUN sed -i "s@httpredir.debian.org@`curl -s -D - http://httpredir.debian.org/demo/debian/ | awk '/^Link:/ { print $2 }' | sed -e 's@<http://\(.*\)/debian/>;@\1@g'`@" /etc/apt/sources.list
 
 # Install apt deps
 RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get install -y \


### PR DESCRIPTION
Prevents sed command from breaking when the retrieved mirror path has a '/' in it

Fixes #2 